### PR TITLE
Added handling for empty/null strings in 'reverseWithStringConcat' and 'reverseWithStringBuilder' functions

### DIFF
--- a/src/com/jwetherell/algorithms/strings/StringFunctions.java
+++ b/src/com/jwetherell/algorithms/strings/StringFunctions.java
@@ -14,6 +14,11 @@ public class StringFunctions {
 
     public static final String reverseWithStringConcat(String string) {
         String output = new String();
+
+        if(string == null || string.IsEmpty()) {
+            return ""
+        }
+
         for (int i = (string.length() - 1); i >= 0; i--) {
             output += (string.charAt(i));
         }
@@ -21,6 +26,11 @@ public class StringFunctions {
     }
 
     public static final String reverseWithStringBuilder(String string) {
+
+        if(string == null || string.IsEmpty()) {
+            return ""
+        }
+
         final StringBuilder builder = new StringBuilder();
         for (int i = (string.length() - 1); i >= 0; i--) {
             builder.append(string.charAt(i));


### PR DESCRIPTION
I have added empty/null string handing functionality to the following two functions in the 'com.jwetherell.algorithms.strings' package:

- reverseWithStringConcat()
- reverseWithStringBuilder()

The updated functionality prevents memory access errors by simply returning an empty string upon receiving either a null or empty string as an argument.
